### PR TITLE
Fix AttributeError when calling 'setup.py test'

### DIFF
--- a/run_all_examples.py
+++ b/run_all_examples.py
@@ -10,6 +10,9 @@ def all_examples():
         filter(lambda f: f.endswith('.txt'), os.listdir(doctests_path))))
     return documentation + doctests
 
-if __name__ == '__main__':
+def test_suite():
     run(all_examples())
+
+if __name__ == '__main__':
+   test_suite()
 


### PR DESCRIPTION
Before fix:

```
running egg_info
creating should_dsl.egg-info
writing should_dsl.egg-info/PKG-INFO
writing top-level names to should_dsl.egg-info/top_level.txt
writing dependency_links to should_dsl.egg-info/dependency_links.txt
writing manifest file 'should_dsl.egg-info/SOURCES.txt'
reading manifest file 'should_dsl.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'should_dsl.egg-info/SOURCES.txt'
running build_ext
Traceback (most recent call last):
  File "setup.py", line 36, in <module>
    test_suite='run_all_examples.test_suite',
  File "/usr/lib/python2.7/distutils/core.py", line 152, in setup
    dist.run_commands()
  File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
    cmd_obj.run()
  File "/home/weslleymberg/.virtualenvs/orchestration/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/command/test.py", line 137, in run
    self.with_project_on_sys_path(self.run_tests)
  File "/home/weslleymberg/.virtualenvs/orchestration/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/command/test.py", line 117, in with_project_on_sys_path
    func()
  File "/home/weslleymberg/.virtualenvs/orchestration/local/lib/python2.7/site-packages/distribute-0.6.24-py2.7.egg/setuptools/command/test.py", line 146, in run_tests
    testLoader = loader_class()
  File "/usr/lib/python2.7/unittest/main.py", line 94, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python2.7/unittest/main.py", line 149, in parseArgs
    self.createTests()
  File "/usr/lib/python2.7/unittest/main.py", line 158, in createTests
    self.module)
  File "/usr/lib/python2.7/unittest/loader.py", line 128, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python2.7/unittest/loader.py", line 100, in loadTestsFromName
    parent, obj = obj, getattr(obj, part)
AttributeError: 'module' object has no attribute 'test_suite'
make: ** [test] Erro 1
```
